### PR TITLE
Correctly apply window insets for edge-to-edge display

### DIFF
--- a/screen/add-items/src/main/java/md/vnastasi/shoppinglist/screen/additems/ui/AddItemsScreen.kt
+++ b/screen/add-items/src/main/java/md/vnastasi/shoppinglist/screen/additems/ui/AddItemsScreen.kt
@@ -2,13 +2,21 @@ package md.vnastasi.shoppinglist.screen.additems.ui
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
-import androidx.compose.foundation.layout.displayCutoutPadding
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
@@ -86,6 +94,7 @@ private fun AddItemsScreen(
         modifier = Modifier
             .fillMaxSize()
             .nestedScroll(scrollBehavior.nestedScrollConnection),
+        contentWindowInsets = WindowInsets.systemBars.union(WindowInsets.displayCutout),
         topBar = {
             Column(
                 modifier = Modifier.fillMaxWidth()
@@ -149,11 +158,12 @@ private fun AddItemsTopAppBar(
 ) {
     TopAppBar(
         modifier = modifier.fillMaxWidth(),
+        windowInsets = WindowInsets.statusBars.union(WindowInsets.displayCutout).only(WindowInsetsSides.Top),
         title = { },
         navigationIcon = {
             IconButton(
                 modifier = Modifier
-                    .displayCutoutPadding()
+                    .windowInsetsPadding(WindowInsets.navigationBars.union(WindowInsets.displayCutout).only(WindowInsetsSides.Start))
                     .testTag(BACK_BUTTON),
                 onClick = onNavigateUp
             ) {
@@ -168,7 +178,7 @@ private fun AddItemsTopAppBar(
             SearchBar(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .displayCutoutPadding()
+                    .windowInsetsPadding(WindowInsets.navigationBars.union(WindowInsets.displayCutout).only(WindowInsetsSides.Start + WindowInsetsSides.End))
                     .padding(start = 56.dp)
                     .testTag(SEARCH_BAR),
                 searchTerm = searchTermState,

--- a/screen/list-details/src/main/java/md/vnastasi/shoppinglist/screen/listdetails/ui/ListDetailsScreen.kt
+++ b/screen/list-details/src/main/java/md/vnastasi/shoppinglist/screen/listdetails/ui/ListDetailsScreen.kt
@@ -4,14 +4,16 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.displayCutout
-import androidx.compose.foundation.layout.displayCutoutPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -31,14 +33,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewDynamicColors
 import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
-import androidx.compose.ui.unit.max
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.persistentListOf
 import md.vnastasi.shoppinglist.domain.model.ShoppingItem
@@ -83,6 +83,7 @@ private fun ListDetailsScreen(
         modifier = Modifier
             .fillMaxSize()
             .nestedScroll(scrollBehavior.nestedScrollConnection),
+        contentWindowInsets = WindowInsets.systemBars.union(WindowInsets.displayCutout),
         topBar = {
             ListDetailsTopAppBar(
                 scrollBehavior = scrollBehavior,
@@ -140,6 +141,7 @@ private fun ListDetailsTopAppBar(
         modifier = modifier
             .fillMaxWidth()
             .testTag(LIST_DETAILS_TOOLBAR),
+        windowInsets = WindowInsets.statusBars.union(WindowInsets.displayCutout).only(WindowInsetsSides.Top),
         title = {
             AnimatedVisibility(
                 visible = !title.isNullOrBlank(),
@@ -151,7 +153,7 @@ private fun ListDetailsTopAppBar(
         },
         navigationIcon = {
             IconButton(
-                modifier = Modifier.displayCutoutPadding(),
+                modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars.union(WindowInsets.displayCutout).only(WindowInsetsSides.Start)),
                 onClick = onNavigateUp
             ) {
                 Icon(
@@ -170,13 +172,9 @@ private fun AddItemsFloatingActionButton(
     modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {
-    val navBarEndPadding = WindowInsets.navigationBars.asPaddingValues().calculateEndPadding(LocalLayoutDirection.current)
-    val displayCutoutEndPadding = WindowInsets.displayCutout.asPaddingValues().calculateEndPadding(LocalLayoutDirection.current)
-    val fabEndPadding = max(navBarEndPadding, displayCutoutEndPadding)
-
     FloatingActionButton(
         modifier = modifier
-            .padding(end = fabEndPadding)
+            .windowInsetsPadding(WindowInsets.navigationBars.union(WindowInsets.displayCutout).only(WindowInsetsSides.Bottom + WindowInsetsSides.End))
             .testTag(ADD_SHOPPING_LIST_ITEMS_FAB),
         shape = RoundedCornerShape(size = AppDimensions.paddingMedium),
         onClick = onClick

--- a/screen/overview/src/main/java/md/vnastasi/shoppinglist/screen/overview/ui/OverviewScreen.kt
+++ b/screen/overview/src/main/java/md/vnastasi/shoppinglist/screen/overview/ui/OverviewScreen.kt
@@ -2,14 +2,17 @@ package md.vnastasi.shoppinglist.screen.overview.ui
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -34,14 +37,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewDynamicColors
 import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
-import androidx.compose.ui.unit.max
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -121,6 +122,7 @@ private fun OverviewScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .nestedScroll(scrollBehavior.nestedScrollConnection),
+            contentWindowInsets = WindowInsets.systemBars.union(WindowInsets.displayCutout),
             topBar = {
                 OverviewTopAppBar(
                     scrollBehavior = scrollBehavior,
@@ -182,6 +184,7 @@ private fun OverviewTopAppBar(
 ) {
     CenterAlignedTopAppBar(
         modifier = modifier.fillMaxWidth(),
+        windowInsets = WindowInsets.statusBars.union(WindowInsets.displayCutout).only(WindowInsetsSides.Top),
         title = {
             Text(
                 text = stringResource(R.string.overview_toolbar_title)
@@ -196,13 +199,10 @@ private fun NewShoppingListFloatingActionButton(
     modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {
-    val navBarEndPadding = WindowInsets.navigationBars.asPaddingValues().calculateEndPadding(LocalLayoutDirection.current)
-    val displayCutoutEndPadding = WindowInsets.displayCutout.asPaddingValues().calculateEndPadding(LocalLayoutDirection.current)
-    val fabEndPadding = max(navBarEndPadding, displayCutoutEndPadding)
 
     FloatingActionButton(
         modifier = modifier
-            .padding(end = fabEndPadding)
+            .windowInsetsPadding(WindowInsets.navigationBars.union(WindowInsets.displayCutout).only(WindowInsetsSides.Bottom + WindowInsetsSides.End))
             .testTag(NEW_SHOPPING_LIST_FAB),
         shape = RoundedCornerShape(size = AppDimensions.paddingMedium),
         onClick = onClick

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[0].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[0].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a675ddf64dcc18f2dbc196acad0457d15825704ad9829935a3d4f58944d298c5
-size 15843
+oid sha256:afc8fe3a2fd65bcf0e190b1497bbfad582d728b7d84101e0c8aa8ddfc686de66
+size 8860

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[10].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[10].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3149d692b0ad01563dbc33edcf3ad8346eb90f85fe692e0d0dff951320af651b
-size 15375
+oid sha256:3d32ac2a256f540de7928f83c96c5419d774656ba7daf4878898375ecf67b195
+size 8021

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[12].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[12].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb78e59c3450c8f2acedb267d8142b1062f75df03fe9c9a81b46edd1aff09699
-size 14299
+oid sha256:6a161c48ea43047e1345d8d2adc7313954d3244e21a3caa7f42125c3f1177d94
+size 6889

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[13].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[13].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2029ec6a475d619dc1444a86488049da11285f6f8f326e55c0918f6e2654db59
-size 13653
+oid sha256:3c5f5b32dcf2658b48766cd9ceeb8fcb88ce9d92e3887180345aab07cd35f037
+size 13631

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[14].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[14].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb78e59c3450c8f2acedb267d8142b1062f75df03fe9c9a81b46edd1aff09699
-size 14299
+oid sha256:6a161c48ea43047e1345d8d2adc7313954d3244e21a3caa7f42125c3f1177d94
+size 6889

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[16].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[16].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8433e16b536f50bbcf9514f08e4f3fc776eea72f4bb65c97c84c2473fe1e95bf
-size 13181
+oid sha256:883be25cc8625cfc582d6da442b2fddbb2ae89e4e261a2b0ed1a952a0176fb2c
+size 8216

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[17].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[17].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7224ec505b60a6b6159952b07bb5fb11b8bbdb694cc1b09422fb541ec10577a
-size 12645
+oid sha256:6ae6eccedfc5735ebd234473d77b9a0be6e7741e798ef86d3fe953da0c9d29af
+size 12554

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[18].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[18].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8433e16b536f50bbcf9514f08e4f3fc776eea72f4bb65c97c84c2473fe1e95bf
-size 13181
+oid sha256:883be25cc8625cfc582d6da442b2fddbb2ae89e4e261a2b0ed1a952a0176fb2c
+size 8216

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[20].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[20].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:87d18224ff117bb7eba765797051e529f72ed4dcf74605ccb0c0d5ca1c3dcbba
-size 12516
+oid sha256:1286926f82404a05ea057e2da8ee3686e0254f188b9ca193fb5c67195edc3501
+size 7502

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[21].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[21].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:57f13fa5b52397620d44d236dfd1dca7ea0e38b52b82ada051fd8355dcddb7ae
-size 11842
+oid sha256:789c9522fd7bdc2d0a178c5d970c85d22a712fdd8fe1372f98085c3362d4d0cb
+size 11766

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[22].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[22].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:87d18224ff117bb7eba765797051e529f72ed4dcf74605ccb0c0d5ca1c3dcbba
-size 12516
+oid sha256:1286926f82404a05ea057e2da8ee3686e0254f188b9ca193fb5c67195edc3501
+size 7502

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[24].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[24].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b8450bb5235c2aa5b58a558a496ce0f90194ebb53a762adbd99dec818f7594f
-size 12904
+oid sha256:937bfb0d636c7a11c59f8cb6dd4ba92c61d51b22ec7e9381ee2f105f1a080baf
+size 7754

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[25].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[25].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ffd7ad943cf24a8a15813d677ec0745768ad695b1e3d52d6246f2bdc155531a
-size 12232
+oid sha256:87b383f9231bb9dfad64bd61b65c50d6b3c253cdb6eb19a9d25497b9ee338c0e
+size 12193

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[26].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[26].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b8450bb5235c2aa5b58a558a496ce0f90194ebb53a762adbd99dec818f7594f
-size 12904
+oid sha256:937bfb0d636c7a11c59f8cb6dd4ba92c61d51b22ec7e9381ee2f105f1a080baf
+size 7754

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[28].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[28].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:543a9ed7e3b639bbff2ec5d7ec2a4a19c1b0a6b68ddfd574a0082d345e79cac1
-size 12354
+oid sha256:b6e9b1f0918b88405ce4ed4275bf97df164cdfb58353216f3089db3bc34d4f6c
+size 7113

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[29].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[29].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e243319e05bfd16e061c109e0193b312d516546f159af6acdfd52cff4985591
-size 11575
+oid sha256:108d0f5e363d8967e7777caaeb794255e7afc9416350fd34c228eea2252fdb1d
+size 11489

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[2].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[2].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a675ddf64dcc18f2dbc196acad0457d15825704ad9829935a3d4f58944d298c5
-size 15843
+oid sha256:afc8fe3a2fd65bcf0e190b1497bbfad582d728b7d84101e0c8aa8ddfc686de66
+size 8860

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[30].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[30].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:543a9ed7e3b639bbff2ec5d7ec2a4a19c1b0a6b68ddfd574a0082d345e79cac1
-size 12354
+oid sha256:b6e9b1f0918b88405ce4ed4275bf97df164cdfb58353216f3089db3bc34d4f6c
+size 7113

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[4].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[4].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7711ee2f8d89ae8d89fae35b259220f7d4c2c3868007f3f64770649e8016b3dc
-size 14569
+oid sha256:a0d83514c5afcced254af3563ac853dc667ccaf5fc7b7bff1894fc7230170136
+size 7506

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[6].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[6].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7711ee2f8d89ae8d89fae35b259220f7d4c2c3868007f3f64770649e8016b3dc
-size 14569
+oid sha256:a0d83514c5afcced254af3563ac853dc667ccaf5fc7b7bff1894fc7230170136
+size 7506

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[8].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[8].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3149d692b0ad01563dbc33edcf3ad8346eb90f85fe692e0d0dff951320af651b
-size 15375
+oid sha256:3d32ac2a256f540de7928f83c96c5419d774656ba7daf4878898375ecf67b195
+size 8021

--- a/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[9].png
+++ b/screen/overview/src/test/snapshots/images/md.vnastasi.shoppinglist.screen.overview.ui_OverviewScreenshotTest_screenshot[9].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7fc46888bc8a88051d7bdfc1ccc5835f33f849a9f1daedc899bb92451ef864ae
-size 15011
+oid sha256:96769880ca48d1182baebfef7f94ae98725c65cd24b46c7c5f5b43119a3b61e3
+size 15272

--- a/support/theme/src/main/java/md/vnastasi/shoppinglist/support/theme/AppDimensions.kt
+++ b/support/theme/src/main/java/md/vnastasi/shoppinglist/support/theme/AppDimensions.kt
@@ -11,7 +11,7 @@ object AppDimensions {
     val paddingLarge = 24.dp
     val paddingExtraLarge = 32.dp
 
-    val contentMaxWidth = 600.dp
+    val contentMaxWidth = 840.dp
     val contentMinWidth = 320.dp
 
     val listItemMinHeight = 54.dp


### PR DESCRIPTION
This commit addresses issues with how window insets were being applied, ensuring a proper edge-to-edge display across different screens.

Key changes:
- Switched from manual padding calculation using `asPaddingValues` and `calculateEndPadding` to the more robust `windowInsetsPadding` modifier.
- Applied `contentWindowInsets` to `Scaffold` to define the area available for content, considering system bars and display cutouts.
- Used `WindowInsets.statusBars.union(WindowInsets.displayCutout).only(WindowInsetsSides.Top)` for top app bars to ensure they are positioned correctly under the status bar and respect display cutouts.
- Utilized `WindowInsets.navigationBars.union(WindowInsets.displayCutout).only(WindowInsetsSides.Bottom + WindowInsetsSides.End)` for Floating Action Buttons to position them correctly respecting navigation bars and display cutouts.
- Applied similar `windowInsetsPadding` adjustments for navigation icons and search bars.
- Increased `AppDimensions.contentMaxWidth` from `600.dp` to `840.dp` to better accommodate larger screen sizes and improve layout consistency.

These changes ensure that UI elements are consistently and correctly positioned within the safe areas of the screen, providing a better user experience on devices with display cutouts or gesture navigation.