### PR TITLE
Fix Kotlin compiler warnings

### DIFF
--- a/screen/shared/src/main/java/md/vnastasi/shoppinglist/screen/shared/toast/ToastMessage.kt
+++ b/screen/shared/src/main/java/md/vnastasi/shoppinglist/screen/shared/toast/ToastMessage.kt
@@ -8,9 +8,9 @@ import kotlinx.collections.immutable.persistentListOf
 
 @Stable
 data class ToastMessage(
-    @StringRes val textResourceId: Int,
+    @get:StringRes val textResourceId: Int,
     val arguments: ImmutableList<Any> = persistentListOf(),
-    @ToastDuration val duration: Int = DURATION_SHORT
+    @get:ToastDuration val duration: Int = DURATION_SHORT
 ) {
 
     companion object {


### PR DESCRIPTION
This commit updates the `ToastMessage` data class to explicitly specify the `@get` annotation target for its `textResourceId` and `duration` properties. This resolves a potential ambiguity and ensures the annotations are correctly applied to the getters of these properties.