### PR TITLE
Add animated transitions between screen view states

### DIFF
--- a/screen/list-details/src/main/java/md/vnastasi/shoppinglist/screen/listdetails/ui/ListDetailsScreen.kt
+++ b/screen/list-details/src/main/java/md/vnastasi/shoppinglist/screen/listdetails/ui/ListDetailsScreen.kt
@@ -1,5 +1,6 @@
 package md.vnastasi.shoppinglist.screen.listdetails.ui
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -52,6 +53,7 @@ import md.vnastasi.shoppinglist.screen.listdetails.ui.TestTags.LIST_DETAILS_TOOL
 import md.vnastasi.shoppinglist.screen.listdetails.vm.ListDetailsViewModelSpec
 import md.vnastasi.shoppinglist.screen.shared.content.AnimatedMessageContent
 import md.vnastasi.shoppinglist.screen.shared.content.LocalBackButtonVisibility
+import md.vnastasi.shoppinglist.screen.shared.content.contentTransitionSpec
 import md.vnastasi.shoppinglist.support.annotation.ExcludeFromJacocoGeneratedReport
 import md.vnastasi.shoppinglist.support.theme.AppDimensions
 import md.vnastasi.shoppinglist.support.theme.AppTheme
@@ -113,29 +115,35 @@ private fun ListDetailsScreen(
             }
         }
     ) { contentPaddings ->
-        when (viewState) {
-            is ViewState.Loading -> {
-                AnimatedMessageContent(
-                    contentPaddings = contentPaddings,
-                    animationResId = R.raw.lottie_anim_loading,
-                    messageResId = R.string.list_details_loading
-                )
-            }
+        AnimatedContent(
+            targetState = viewState,
+            contentKey = { it::class },
+            transitionSpec = { contentTransitionSpec }
+        ) { viewState ->
+            when (viewState) {
+                is ViewState.Loading -> {
+                    AnimatedMessageContent(
+                        contentPaddings = contentPaddings,
+                        animationResId = R.raw.lottie_anim_loading,
+                        messageResId = R.string.list_details_loading
+                    )
+                }
 
-            is ViewState.Empty -> {
-                AnimatedMessageContent(
-                    contentPaddings = contentPaddings,
-                    animationResId = R.raw.lottie_anim_empty_box,
-                    messageResId = R.string.list_details_empty
-                )
-            }
+                is ViewState.Empty -> {
+                    AnimatedMessageContent(
+                        contentPaddings = contentPaddings,
+                        animationResId = R.raw.lottie_anim_empty_box,
+                        messageResId = R.string.list_details_empty
+                    )
+                }
 
-            is ViewState.Ready -> {
-                ListDetailsContent(
-                    contentPaddings = contentPaddings,
-                    listOfShoppingItems = viewState.listOfShoppingItems,
-                    dispatchEvent = dispatchEvent
-                )
+                is ViewState.Ready -> {
+                    ListDetailsContent(
+                        contentPaddings = contentPaddings,
+                        listOfShoppingItems = viewState.listOfShoppingItems,
+                        dispatchEvent = dispatchEvent
+                    )
+                }
             }
         }
     }

--- a/screen/overview/src/main/java/md/vnastasi/shoppinglist/screen/overview/ui/OverviewScreen.kt
+++ b/screen/overview/src/main/java/md/vnastasi/shoppinglist/screen/overview/ui/OverviewScreen.kt
@@ -1,5 +1,6 @@
 package md.vnastasi.shoppinglist.screen.overview.ui
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.displayCutout
@@ -45,6 +46,7 @@ import md.vnastasi.shoppinglist.screen.overview.nav.OverviewScreenNavigator
 import md.vnastasi.shoppinglist.screen.overview.ui.TestTags.NEW_SHOPPING_LIST_FAB
 import md.vnastasi.shoppinglist.screen.overview.vm.OverviewViewModelSpec
 import md.vnastasi.shoppinglist.screen.shared.content.AnimatedMessageContent
+import md.vnastasi.shoppinglist.screen.shared.content.contentTransitionSpec
 import md.vnastasi.shoppinglist.support.annotation.ExcludeFromJacocoGeneratedReport
 import md.vnastasi.shoppinglist.support.theme.AppDimensions
 import md.vnastasi.shoppinglist.support.theme.AppTheme
@@ -105,29 +107,35 @@ private fun OverviewScreen(
             }
         }
     ) { contentPaddings ->
-        when (viewState) {
-            is ViewState.Loading -> {
-                AnimatedMessageContent(
-                    contentPaddings = contentPaddings,
-                    animationResId = R.raw.lottie_anim_loading,
-                    messageResId = R.string.overview_loading
-                )
-            }
+        AnimatedContent(
+            targetState = viewState,
+            contentKey = { it::class },
+            transitionSpec = { contentTransitionSpec }
+        ) { viewState ->
+            when (viewState) {
+                is ViewState.Loading -> {
+                    AnimatedMessageContent(
+                        contentPaddings = contentPaddings,
+                        animationResId = R.raw.lottie_anim_loading,
+                        messageResId = R.string.overview_loading
+                    )
+                }
 
-            is ViewState.Empty -> {
-                AnimatedMessageContent(
-                    contentPaddings = contentPaddings,
-                    animationResId = R.raw.lottie_anim_shopping_cart,
-                    messageResId = R.string.overview_empty_list
-                )
-            }
+                is ViewState.Empty -> {
+                    AnimatedMessageContent(
+                        contentPaddings = contentPaddings,
+                        animationResId = R.raw.lottie_anim_shopping_cart,
+                        messageResId = R.string.overview_empty_list
+                    )
+                }
 
-            is ViewState.Ready -> {
-                OverviewContent(
-                    contentPaddings = contentPaddings,
-                    list = viewState.data,
-                    dispatchEvent = dispatchEvent
-                )
+                is ViewState.Ready -> {
+                    OverviewContent(
+                        contentPaddings = contentPaddings,
+                        list = viewState.data,
+                        dispatchEvent = dispatchEvent
+                    )
+                }
             }
         }
     }

--- a/screen/shared/src/main/java/md/vnastasi/shoppinglist/screen/shared/content/ContentTransition.kt
+++ b/screen/shared/src/main/java/md/vnastasi/shoppinglist/screen/shared/content/ContentTransition.kt
@@ -1,0 +1,38 @@
+package md.vnastasi.shoppinglist.screen.shared.content
+
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.togetherWith
+
+private const val EXIT_TRANSITION_DURATION = 500
+private const val EXIT_TRANSITION_DELAY = 90
+private const val EXIT_TRANSITION_SCALE = 0.92f
+
+private val contentEnterTransition: EnterTransition =
+    fadeIn(
+        animationSpec = tween(
+            durationMillis = EXIT_TRANSITION_DURATION,
+            delayMillis = EXIT_TRANSITION_DELAY
+        )
+    ) + scaleIn(
+        initialScale = EXIT_TRANSITION_SCALE,
+        animationSpec = tween(
+            durationMillis = EXIT_TRANSITION_DURATION,
+            delayMillis = EXIT_TRANSITION_DELAY
+        )
+    )
+
+private val contentExitTransition: ExitTransition =
+    fadeOut(
+        animationSpec = tween(
+            durationMillis = EXIT_TRANSITION_DURATION
+        )
+    )
+
+val contentTransitionSpec: ContentTransform =
+    contentEnterTransition togetherWith contentExitTransition


### PR DESCRIPTION
* Create `ContentTransition.kt` in the `shared` module to define a reusable `contentTransitionSpec`.
    - Configure an enter transition using combined `fadeIn` and `scaleIn` with a 500ms duration and 90ms delay.
    - Configure an exit transition using `fadeOut` with a 500ms duration.
* Update `OverviewScreen` and `ListDetailsScreen` to use `AnimatedContent` when switching between `Loading`, `Empty`, and `Ready` view states.
* Use the view state class as the `contentKey` in `AnimatedContent` to ensure transitions trigger correctly when the state type changes.